### PR TITLE
Update script check decimals/places if int

### DIFF
--- a/FeatureServiceAliasAndDescriptionUpdate_mulitipleLayers.py
+++ b/FeatureServiceAliasAndDescriptionUpdate_mulitipleLayers.py
@@ -185,7 +185,7 @@ else:
                         # Check if there is a decimal spec
                         if "format" in i and "places" in i["format"]:
                             # If a value is specified in the lookup doc, assign that
-                            if lookup[4] != None:
+                            if lookup[4] != None and isinstance(lookup[4], int):
                                 newItemJSON['layers'][looper]['popupInfo']['fieldInfos'][counter]['format']['places'] = lookup[4]
                             # If a value is not specified and the decimals have defaulted to 6, change to 2
                             else:
@@ -215,7 +215,7 @@ else:
                                         # Check if there is a decimal spec
                                         if "format" in j and "places" in j["format"]:
                                             # If a value is specified in the lookup doc, assign that
-                                            if lkup[4] != None:
+                                            if lkup[4] != None and isinstance(lkup[4], int):
                                                 newItemJSON['layers'][looper]['popupInfo']['popupElements'][c]["fieldInfos"][counter2]['format']['places'] = lkup[4]
                                             # If a value is not specified and the decimals have defaulted to 6, change to 2
                                             else:
@@ -241,3 +241,4 @@ else:
 
         looper += 1
         restLayerCount -= 1
+


### PR DESCRIPTION
We had a Bug that excel gave back an empty string "" (which is invissable in excel), but when places, became:
```
{
  "fieldName": "OBJECTID",
  "isEditable": false,
  "format": {
    "places": "",
    "digitSeparator": true
  },
  "visible": false,
  "label": "Object_id"
},
```
Both the attribute table and the pop up broke/ showed errors/nothing in arcgis online